### PR TITLE
gmflow: opt-in non-linear schedule support for posterior_mean

### DIFF
--- a/lakonlab/models/diffusions/gmflow.py
+++ b/lakonlab/models/diffusions/gmflow.py
@@ -72,6 +72,57 @@ def gmflow_posterior_mean_jit(
     return out_mean
 
 
+@torch.jit.script
+def gmflow_posterior_mean_jit_general(
+        alpha_t_src, sigma_t_src, alpha_t, sigma_t, x_t_src, x_t,
+        gm_means, gm_vars, gm_logweights,
+        eps: float, gm_dim: int = -4, channel_dim: int = -3):
+    """Schedule-agnostic generalization of `gmflow_posterior_mean_jit`.
+
+    Accepts an arbitrary noise schedule via explicit `(alpha, sigma)` pairs
+    instead of assuming the linear/VE relation `alpha = 1 - sigma`. When
+    `alpha_t_src = 1 - sigma_t_src` and `alpha_t = 1 - sigma_t`, the output
+    is bit-exact identical to `gmflow_posterior_mean_jit` (verified across
+    20 seeds * 5 (B,K,C,H,W) configs in float32 + float64; see
+    `derivations/_test_differential_equivalence.py` in the parent repo).
+
+    The mathematical derivation (information-form Bayesian update of a
+    Gaussian-mixture prior with two Gaussian observations) is documented in
+    `derivations/01_posterior_rederivation.ipynb` (SymPy + numerical) and
+    `derivations/posterior_rederivation.nb` (Mathematica). The simplified
+    `logweights_delta` term used here is exact for the GMFlow case where
+    `gm_vars` is shared across the K mixture components (proven k-independent
+    in the Mathematica notebook; the precondition is enforced by the existing
+    GMFlow code paths).
+
+    The operator order in `nu` (`aos * x / sigma`, two divides) deliberately
+    mirrors `gmflow_posterior_mean_jit` so that the linear-schedule path is
+    bit-exact, not just within float epsilon.
+    """
+    sigma_t_src = sigma_t_src.clamp(min=eps)
+    sigma_t = sigma_t.clamp(min=eps)
+
+    alpha_over_sigma_t_src = alpha_t_src / sigma_t_src
+    alpha_over_sigma_t = alpha_t / sigma_t
+
+    zeta = alpha_over_sigma_t.square() - alpha_over_sigma_t_src.square()
+    nu = alpha_over_sigma_t * x_t / sigma_t - alpha_over_sigma_t_src * x_t_src / sigma_t_src
+
+    nu = nu.unsqueeze(gm_dim)  # (bs, *, 1, out_channels, h, w)
+    zeta = zeta.unsqueeze(gm_dim)  # (bs, *, 1, 1, 1, 1)
+    denom = (gm_vars * zeta + 1).clamp(min=eps)
+
+    out_means = (gm_vars * nu + gm_means) / denom
+    # (bs, *, num_gaussians, 1, h, w)
+    logweights_delta = (gm_means * (nu - 0.5 * zeta * gm_means)).sum(
+        dim=channel_dim, keepdim=True) / denom
+    out_weights = (gm_logweights + logweights_delta).softmax(dim=gm_dim)
+
+    out_mean = (out_means * out_weights).sum(dim=gm_dim)
+
+    return out_mean
+
+
 class GMFlowMixin:
 
     @property

--- a/lakonlab/models/diffusions/gmflow.py
+++ b/lakonlab/models/diffusions/gmflow.py
@@ -168,10 +168,18 @@ class GMFlowMixin:
 
     def gmflow_posterior_mean(
             self, gm, x_t, x_t_src, t=None, t_src=None,
-            sigma_t_src=None, sigma_t=None, eps=1e-6, prediction_type='x0',
+            sigma_t_src=None, sigma_t=None,
+            alpha_t_src=None, alpha_t=None,
+            eps=1e-6, prediction_type='x0',
             checkpointing=False):
         """
         Fuse gmflow_posterior and gm_to_mean to avoid redundant computation.
+
+        Pass `alpha_t_src` and/or `alpha_t` to select a non-linear noise
+        schedule (e.g. VP: alpha=cos(pi*t/2), sigma=sin(pi*t/2)); the missing
+        member of the pair is filled in with `1 - sigma`. When both are
+        omitted, the call routes to the legacy `gmflow_posterior_mean_jit`
+        and behavior is bit-exact identical to prior versions.
         """
         assert isinstance(gm, dict)
 
@@ -200,16 +208,26 @@ class GMFlowMixin:
             gm_vars = (gm['logstds'] * 2).exp()  # (bs, *, 1, 1, 1, 1)
             gm['gm_vars'] = gm_vars
 
+        use_general = alpha_t_src is not None or alpha_t is not None
+        if use_general:
+            if alpha_t_src is None:
+                alpha_t_src = 1 - sigma_t_src
+            if alpha_t is None:
+                alpha_t = 1 - sigma_t
+            jit_fn = gmflow_posterior_mean_jit_general
+            args = (alpha_t_src, sigma_t_src, alpha_t, sigma_t, x_t_src, x_t,
+                    gm_means, gm_vars, gm_logweights, eps)
+        else:
+            jit_fn = gmflow_posterior_mean_jit
+            args = (sigma_t_src, sigma_t, x_t_src, x_t,
+                    gm_means, gm_vars, gm_logweights, eps)
+
         if checkpointing and torch.is_grad_enabled():
             return torch.utils.checkpoint.checkpoint(
-                gmflow_posterior_mean_jit,
-                sigma_t_src, sigma_t, x_t_src, x_t,
-                gm_means, gm_vars, gm_logweights, eps,
+                jit_fn, *args,
                 use_reentrant=True)  # use_reentrant=False does not work with jit
         else:
-            return gmflow_posterior_mean_jit(
-                sigma_t_src, sigma_t, x_t_src, x_t,
-                gm_means, gm_vars, gm_logweights, eps)
+            return jit_fn(*args)
 
     def reverse_transition(self, denoising_output, x_t_high, t_low, t_high, eps=1e-6, prediction_type='u'):
         if isinstance(denoising_output, dict):


### PR DESCRIPTION
## Summary

Adds schedule-agnostic support to `GMFlowMixin.gmflow_posterior_mean` via two opt-in kwargs (`alpha_t_src`, `alpha_t`). Default behavior is **bit-exact identical** to the current implementation — when neither kwarg is passed, dispatch routes to the existing `gmflow_posterior_mean_jit` unchanged.

Two commits, layered for easy review:

1. **`5aa195b` add `gmflow_posterior_mean_jit_general` (schedule-agnostic sibling)**  
   New top-level `@torch.jit.script` function that takes `(alpha_t_src, sigma_t_src, alpha_t, sigma_t, ...)` instead of assuming `alpha = 1 - sigma`. Pure addition; no existing call sites touched.

2. **`6190862` `gmflow_posterior_mean`: opt-in alpha kwargs route to general jit**  
   Wrapper now accepts `alpha_t_src` / `alpha_t`. When either is provided, the missing one auto-fills as `1 - sigma_*` and the call routes to the general JIT. When neither is provided, calls the legacy JIT exactly as before (preserved through `checkpointing` path too).

Motivation: lets downstream code (e.g. VP-schedule diffusions where `alpha = cos(pi*t/2)`, `sigma = sin(pi*t/2)`) reuse the GM posterior machinery without forking the file.

## Verification

A standalone numerical test (`_test_wrapper_dispatch.py`, lives in the consuming repo) extracts both JIT functions from this source and proves:

- **Source audit** — the new dispatch tokens (`alpha_t_src=None`, `alpha_t=None`, `use_general = ...`, both JIT names) are present in the method body.
- **Linear-schedule equivalence** — across 5 shape/dtype configs × 20 seeds, four call patterns (default, both alphas explicit, only `alpha_t_src`, only `alpha_t`) produce **bit-exact** identical outputs (`max_abs = 0.0e+00`) when the alphas are set to `1 - sigma`.
- **VP smoke** — passing `alpha = cos(pi*t/2)`, `sigma = sin(pi*t/2)` runs without error and stays finite/bounded.

Result on this branch:
\`\`\`
[audit] all expected dispatch tokens present
(B=2, K=4, C=3, H=8, W=8)    float32    0.000e+00      PASS
(B=2, K=8, C=16, H=16, W=16) float32    0.000e+00      PASS
(B=4, K=4, C=64, H=32, W=32) float32    0.000e+00      PASS
(B=1, K=4, C=3, H=8, W=8)    float64    0.000e+00      PASS
(B=2, K=8, C=16, H=16, W=16) float64    0.000e+00      PASS
VP smoke: all_finite=True  max_abs=5.102e+00  PASS
=== ALL PASS ===
\`\`\`

A separate test (`_test_differential_equivalence.py`, also downstream) already proves that `gmflow_posterior_mean_jit` and `gmflow_posterior_mean_jit_general` agree analytically when `alpha = 1 - sigma`.

## Test plan

- [x] Bit-exact equivalence vs. legacy JIT under linear schedule (40+ random batches, fp32 + fp64).
- [x] All four opt-in patterns produce identical outputs.
- [x] VP-schedule call path stays finite.
- [ ] Reviewer: optional sanity check by running the existing GMFlow training/eval scripts — no caller passes the new kwargs, so behavior should be unchanged.