### PR TITLE
Add ComfyUI-AsymFlux2 custom-node package

### DIFF
--- a/comfyui/ComfyUI-AsymFlux2/.gitignore
+++ b/comfyui/ComfyUI-AsymFlux2/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.safetensors
+.pytest_cache/

--- a/comfyui/ComfyUI-AsymFlux2/README.md
+++ b/comfyui/ComfyUI-AsymFlux2/README.md
@@ -1,0 +1,138 @@
+# ComfyUI-AsymFlux2
+
+ComfyUI nodes for **Lakonik's AsymFLUX.2-klein-9B**
+([HuggingFace](https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B),
+[paper](https://hanshengchen.com/asymflow)).
+
+AsymFLUX.2 is a *pixel-space* finetune of FLUX.2-klein-9B that uses
+"rank-asymmetric flow parameterization" — the 707 MB adapter file is a hybrid
+of (a) full-weight replacements for the I/O projections and (b) rank-256 LoRA
+deltas for 58 internal modules. It is **not** a plain LoRA, and it
+**changes the model's input shape** from a 128-channel VAE latent to a
+3-channel pixel image.
+
+## Install
+
+Clone or copy this folder into `ComfyUI/custom_nodes/`:
+
+```bash
+cd ComfyUI/custom_nodes/
+git clone <this repo>/comfyui/ComfyUI-AsymFlux2
+```
+
+Place the adapter safetensors in `ComfyUI/models/asymflux2/`:
+
+```bash
+# in your ComfyUI install:
+mkdir -p models/asymflux2
+huggingface-cli download Lakonik/AsymFLUX.2-klein-9B \
+    diffusion_pytorch_model.safetensors \
+    --local-dir models/asymflux2/
+```
+
+You also need the base model already working: **FLUX.2-klein-base-9B** must be
+downloaded and loadable by ComfyUI's standard `UNETLoader` /
+`CheckpointLoaderSimple`. ComfyUI core has supported FLUX.2 since commit
+[`6b573ae`](https://github.com/comfyanonymous/ComfyUI/commit/6b573ae)
+(Nov 25 2025).
+
+## Nodes
+
+| Node | Inputs | Output |
+|---|---|---|
+| **AsymFlux2 Load Adapter** | `MODEL`, `adapter_name` | `MODEL` (patched) |
+| **AsymFlux2 Empty Latent (pixel)** | width, height, batch | `LATENT` (3 × H × W) |
+| **AsymFlux2 Sigmas (sqrt-shift)** | steps, width, height | `SIGMAS` |
+| **Oklab Encode** | `IMAGE` | `LATENT` |
+| **Oklab Decode** | `LATENT` | `IMAGE` |
+
+### Sample graph
+
+```
+[UNETLoader (FLUX.2-klein-base-9B)] ─┐
+                                     ▼
+                          [AsymFlux2 Load Adapter] ──► MODEL
+[CLIPLoader] ──► CLIP                                   │
+[CLIPTextEncode] ──► positive ──┐                       │
+[CLIPTextEncode] ──► negative ──┤                       │
+[AsymFlux2 Empty Latent]   ─────┤                       │
+[AsymFlux2 Sigmas]         ─────┤                       │
+[KSamplerSelect (uni_pc)]  ─────┴── [SamplerCustom] ────┘
+                                          │
+                                       LATENT
+                                          ▼
+                                   [Oklab Decode]
+                                          ▼
+                                       [SaveImage]
+```
+
+## How the adapter loader works
+
+The 707 MB safetensors contains exactly **121 tensors**, split as:
+
+- 5 full-weight overrides:
+  `x_embedder.weight`, `proj_out.weight`, `norm_out.linear.weight`,
+  `proj_buffer`, `scale_buffer`.
+- 116 LoRA tensors (rank 256, alpha 256 → scaling 1.0) targeting 58 modules
+  across `transformer_blocks` (8), `single_transformer_blocks` (24), and
+  `time_guidance_embed.timestep_embedder`.
+
+Diffusers-style names are translated to ComfyUI's BFL-style FLUX names by
+`key_map.LORA_MAP` and `key_map.FULL_OVERRIDES`. The loader (`adapter_loader.apply_adapter`):
+
+1. Replaces `img_in` with a fresh `nn.Linear(768, 4096)` and copies in the
+   adapter's `x_embedder.weight`. Replaces `final_layer.linear` similarly.
+2. Overwrites `final_layer.adaLN_modulation.1.weight` from `norm_out.linear.weight`.
+3. Registers `proj_buffer` (768 × 128) and `scale_buffer` (scalar) on the
+   transformer.
+4. For each of the 58 LoRA targets, fuses `delta = B @ A * scaling` into the
+   existing weight (math done in fp32, then cast back).
+5. Sets `transformer.patch_size = 16`, `in_channels = out_channels = 768`
+   so `Flux.process_img` patchifies the pixel-resolution input correctly.
+
+## Testing
+
+Three test suites that run without ComfyUI:
+
+```bash
+python tests/test_key_translation.py    # 5/5 — ground truth: real 121-key dump
+python tests/test_scheduler.py          # 5/5 — vs LakonLab reference math
+python tests/test_apply_adapter.py      # 6/6 — surgery primitives
+python tests/test_oklab.py              # 4/4 — color round-trips
+```
+
+## Known unknowns / things to verify on first real run
+
+These can't be verified without the real 9 B base model + a GPU, so they're
+flagged here for the first end-to-end run:
+
+1. **`final_layer.adaLN_modulation.1` is assumed to be the right target for
+   `norm_out.linear.weight`.** ComfyUI's `LastLayer` source wasn't inspectable
+   via static fetch; the layout (`Sequential(SiLU, Linear)` with the linear at
+   index 1) is the canonical FLUX layout but worth double-checking on the
+   first error.
+2. **The model's `process_img` may not respect the post-hoc `patch_size = 16`
+   change cleanly** if it caches anything at construction time. If you see a
+   shape mismatch in the first denoise step, the fix is to construct the
+   `Flux` module with `patch_size=16, in_channels=3` from the start (i.e. a
+   custom model-config registration) instead of patching it after.
+3. **Positional embedding (`pe_embedder`) is shape-agnostic** in ComfyUI's
+   `EmbedND`, but a 60×80 token grid at patch 16 has 4× the token count of
+   the equivalent latent FLUX.2 run. Performance/memory will rise accordingly.
+4. **The `scale_buffer` is registered but not yet consumed** by anything in
+   this package — LakonLab's pipeline reads it inside `prepare_latents` for
+   scaling the initial noise. If image contrast looks off on the first run,
+   that's the likely culprit; the fix is to multiply the initial empty latent
+   by `scale_buffer`.
+5. **ComfyUI's `ModelPatcher` may dislike module replacement.** The loader
+   does `unpatch_model()` before the surgery to keep its bookkeeping happy,
+   but low-VRAM users may need to disable smart-offloading.
+
+If any of these bite, the fixes are small and localized — file an issue with
+the traceback.
+
+## License
+
+Code in this folder: Apache 2.0.
+Adapter weights from `Lakonik/AsymFLUX.2-klein-9B`: see upstream license.
+Base model `FLUX.2-klein-base-9B`: subject to Black Forest Labs' license.

--- a/comfyui/ComfyUI-AsymFlux2/__init__.py
+++ b/comfyui/ComfyUI-AsymFlux2/__init__.py
@@ -1,0 +1,27 @@
+"""ComfyUI custom-node package for Lakonik AsymFLUX.2-klein-9B.
+
+Drop this folder into `ComfyUI/custom_nodes/`. The package:
+
+  1. registers a `models/asymflux2/` directory (so the safetensors file can
+     be placed alongside other model weights and shows up in the dropdown);
+  2. exposes 5 nodes under the "AsymFlux2" category (see nodes.py for the
+     full graph diagram).
+"""
+
+import os
+
+import folder_paths
+
+from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+
+# Register a new model-type folder so the adapter safetensors is discoverable
+# from anywhere in ComfyUI's models tree.
+_models_dir = os.path.join(folder_paths.models_dir, 'asymflux2')
+os.makedirs(_models_dir, exist_ok=True)
+folder_paths.folder_names_and_paths['asymflux2'] = (
+    [_models_dir],
+    folder_paths.supported_pt_extensions,
+)
+
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/comfyui/ComfyUI-AsymFlux2/adapter_loader.py
+++ b/comfyui/ComfyUI-AsymFlux2/adapter_loader.py
@@ -1,0 +1,197 @@
+"""Apply a translated AsymFLUX.2 adapter onto a stock ComfyUI FLUX.2 transformer.
+
+The transformer is the `Flux` nn.Module from `comfy/ldm/flux/model.py`. After
+this function runs:
+
+  - `img_in`               has been replaced by `nn.Linear(768, hidden)` (no bias).
+  - `final_layer.linear`   has been replaced by `nn.Linear(hidden, 768)` (no bias).
+  - `final_layer.adaLN_modulation.1.weight` has been overwritten.
+  - Two buffers (`proj_buffer`, `scale_buffer`) are registered on the transformer.
+  - 58 weight tensors across `double_blocks`/`single_blocks`/`time_in` have a
+    rank-256 LoRA delta fused into them.
+
+Numerics: the delta is computed in float32, then cast back to the existing
+parameter's dtype to match how PEFT does `fuse_lora` and how LakonLab loads
+the adapter.
+"""
+
+import torch
+import torch.nn as nn
+
+try:
+    from .key_map import (
+        translate, LORA_SCALING,
+        ASYMFLUX_HIDDEN, ASYMFLUX_IN_CHANNELS,
+        ASYMFLUX_OUT_CHANNELS, ASYMFLUX_PATCH_SIZE,
+    )
+except ImportError:  # standalone-import path (tests, ad-hoc usage)
+    from key_map import (
+        translate, LORA_SCALING,
+        ASYMFLUX_HIDDEN, ASYMFLUX_IN_CHANNELS,
+        ASYMFLUX_OUT_CHANNELS, ASYMFLUX_PATCH_SIZE,
+    )
+
+
+def _get_submodule(root: nn.Module, dotted_path: str) -> nn.Module:
+    obj = root
+    for part in dotted_path.split('.'):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _set_submodule(root: nn.Module, dotted_path: str, value: nn.Module) -> None:
+    parts = dotted_path.split('.')
+    parent = root
+    for part in parts[:-1]:
+        parent = getattr(parent, part)
+    setattr(parent, parts[-1], value)
+
+
+def _get_param(root: nn.Module, dotted_path: str) -> torch.nn.Parameter:
+    # dotted_path is like "final_layer.adaLN_modulation.1.weight" -> walk to
+    # the `weight` Parameter on the leaf module.
+    *module_parts, leaf = dotted_path.split('.')
+    mod = root
+    for part in module_parts:
+        mod = getattr(mod, part)
+    return getattr(mod, leaf)
+
+
+def _fuse_lora_into_weight(
+        weight: torch.nn.Parameter,
+        lora_A: torch.Tensor,  # (rank, in_features)
+        lora_B: torch.Tensor,  # (out_features, rank)
+        scaling: float,
+) -> None:
+    """In-place: weight += (B @ A) * scaling, computed in float32."""
+    out_features, in_features = weight.shape
+    assert lora_A.shape == (lora_B.shape[1], in_features), \
+        f'lora_A {tuple(lora_A.shape)} incompatible with weight {tuple(weight.shape)}'
+    assert lora_B.shape == (out_features, lora_A.shape[0]), \
+        f'lora_B {tuple(lora_B.shape)} incompatible with weight {tuple(weight.shape)}'
+
+    target_dtype = weight.dtype
+    target_device = weight.device
+
+    delta = (lora_B.to(torch.float32, copy=False)
+             @ lora_A.to(torch.float32, copy=False)) * scaling
+    with torch.no_grad():
+        weight.add_(delta.to(dtype=target_dtype, device=target_device))
+
+
+def apply_adapter(
+        transformer: nn.Module,
+        adapter_state_dict: dict,
+        compute_dtype: torch.dtype = torch.bfloat16,
+        strict: bool = True,
+) -> dict:
+    """Mutate `transformer` in place. Returns a manifest describing what changed.
+
+    Args:
+        transformer: the inner `Flux` nn.Module (NOT the ModelPatcher wrapper).
+        adapter_state_dict: {key: Tensor} from the safetensors file.
+        compute_dtype: dtype used for the new replacement modules.
+        strict: if True, raise on any unknown adapter key or missing translation
+            target. If False, log and skip.
+
+    Returns:
+        manifest: a dict with keys 'replaced_modules', 'overwrote_weights',
+        'registered_buffers', 'fused_loras', 'skipped'.
+    """
+    plan = translate(adapter_state_dict)
+
+    if plan.unknown_keys:
+        msg = f'Unknown adapter keys ({len(plan.unknown_keys)}): {plan.unknown_keys[:5]}...'
+        if strict:
+            raise KeyError(msg)
+        print(f'[asymflux2] warning: {msg}')
+
+    manifest = {
+        'replaced_modules': [],
+        'overwrote_weights': [],
+        'registered_buffers': [],
+        'fused_loras': [],
+        'skipped': [],
+    }
+
+    # 1. Replace modules with shape-changing surgery.
+    for bfl_path, (expected_shape, tensor) in plan.module_replacements.items():
+        if tuple(tensor.shape) != expected_shape:
+            raise ValueError(
+                f'{bfl_path}: adapter tensor shape {tuple(tensor.shape)} != '
+                f'expected {expected_shape}')
+        out_features, in_features = expected_shape
+        try:
+            existing = _get_submodule(transformer, bfl_path)
+        except AttributeError:
+            if strict:
+                raise AttributeError(f'transformer has no submodule "{bfl_path}"')
+            manifest['skipped'].append(bfl_path)
+            continue
+
+        device = next(existing.parameters()).device if any(True for _ in existing.parameters()) else 'cpu'
+        new_linear = nn.Linear(in_features, out_features, bias=False,
+                               device=device, dtype=compute_dtype)
+        with torch.no_grad():
+            new_linear.weight.copy_(tensor.to(dtype=compute_dtype, device=device))
+        _set_submodule(transformer, bfl_path, new_linear)
+        manifest['replaced_modules'].append(bfl_path)
+
+    # 2. Overwrite individual weight tensors in place.
+    for bfl_param_path, tensor in plan.weight_overrides.items():
+        try:
+            param = _get_param(transformer, bfl_param_path)
+        except AttributeError:
+            if strict:
+                raise AttributeError(f'transformer has no parameter "{bfl_param_path}"')
+            manifest['skipped'].append(bfl_param_path)
+            continue
+        if tuple(param.shape) != tuple(tensor.shape):
+            raise ValueError(
+                f'{bfl_param_path}: base shape {tuple(param.shape)} != '
+                f'adapter shape {tuple(tensor.shape)}')
+        with torch.no_grad():
+            param.copy_(tensor.to(dtype=param.dtype, device=param.device))
+        manifest['overwrote_weights'].append(bfl_param_path)
+
+    # 3. Register new buffers.
+    device = next(transformer.parameters()).device
+    for name, tensor in plan.buffers.items():
+        transformer.register_buffer(
+            name, tensor.to(device=device).clone(), persistent=False)
+        manifest['registered_buffers'].append(name)
+
+    # 4. Fuse LoRA deltas.
+    for bfl_module_path, halves in plan.lora_pairs.items():
+        if set(halves.keys()) != {'A', 'B'}:
+            if strict:
+                raise KeyError(f'{bfl_module_path}: incomplete LoRA pair {list(halves)}')
+            manifest['skipped'].append(bfl_module_path)
+            continue
+        try:
+            module = _get_submodule(transformer, bfl_module_path)
+        except AttributeError:
+            if strict:
+                raise AttributeError(f'transformer has no submodule "{bfl_module_path}"')
+            manifest['skipped'].append(bfl_module_path)
+            continue
+
+        weight = module.weight
+        try:
+            _fuse_lora_into_weight(weight, halves['A'], halves['B'], LORA_SCALING)
+        except AssertionError as exc:
+            raise ValueError(f'{bfl_module_path}: {exc}') from None
+        manifest['fused_loras'].append(bfl_module_path)
+
+    return manifest
+
+
+def asymflux2_model_config() -> dict:
+    """The architecture parameters a ComfyUI FluxParams must be set to in order
+    for img_in / final_layer.linear / patch grid to match the adapter."""
+    return {
+        'patch_size':   ASYMFLUX_PATCH_SIZE,
+        'in_channels':  ASYMFLUX_IN_CHANNELS,
+        'out_channels': ASYMFLUX_OUT_CHANNELS,
+        'hidden_size':  ASYMFLUX_HIDDEN,
+    }

--- a/comfyui/ComfyUI-AsymFlux2/key_map.py
+++ b/comfyui/ComfyUI-AsymFlux2/key_map.py
@@ -1,0 +1,162 @@
+"""Translation table between Lakonik AsymFLUX.2 adapter keys (diffusers naming)
+and ComfyUI's FLUX.2 module names (BFL/original naming).
+
+Source of truth: the 121-key dump produced from
+`Lakonik/AsymFLUX.2-klein-9B/diffusion_pytorch_model.safetensors`.
+
+The adapter contains:
+  - 5 full-weight tensors that REPLACE base-model state (some require module
+    surgery because their shapes differ from the base FLUX.2 latent model).
+  - 116 LoRA tensors (rank 256, alpha 256 -> scaling 1.0) targeting 58 modules:
+      * double_blocks {0..7}: img_mlp.0, img_mlp.2, txt_mlp.0, txt_mlp.2  (32 tgts)
+      * single_blocks {0..23}: linear2                                    (24 tgts)
+      * time_in: in_layer, out_layer                                       ( 2 tgts)
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+NUM_DOUBLE_BLOCKS = 8
+NUM_SINGLE_BLOCKS = 24
+
+LORA_RANK = 256
+LORA_ALPHA = 256
+LORA_SCALING = LORA_ALPHA / LORA_RANK  # = 1.0
+
+OKLAB_AFFINE_MEAN = (0.56, 0.0, 0.01)
+OKLAB_AFFINE_STD = 0.16
+
+ASYMFLUX_PATCH_SIZE = 16
+ASYMFLUX_IN_CHANNELS = 3
+ASYMFLUX_OUT_CHANNELS = 3
+ASYMFLUX_HIDDEN = 4096
+ASYMFLUX_BASE_RANK = 128  # rank of the asymmetric PCA subspace (proj_buffer width)
+
+
+# Full-weight overrides. The dict value is a callable that returns the BFL-side
+# action: ('weight', bfl_key) overwrites a parameter in-place;
+# ('module_replace', bfl_module, expected_shape) replaces a Linear submodule;
+# ('buffer', name) registers a new top-level buffer.
+FULL_OVERRIDES = {
+    # diffusers key                  : action tuple
+    'x_embedder.weight':              ('module_replace', 'img_in',
+                                       (ASYMFLUX_HIDDEN, ASYMFLUX_IN_CHANNELS * ASYMFLUX_PATCH_SIZE ** 2)),
+    'proj_out.weight':                ('module_replace', 'final_layer.linear',
+                                       (ASYMFLUX_OUT_CHANNELS * ASYMFLUX_PATCH_SIZE ** 2, ASYMFLUX_HIDDEN)),
+    'norm_out.linear.weight':         ('weight', 'final_layer.adaLN_modulation.1.weight'),
+    'proj_buffer':                    ('buffer', 'proj_buffer'),
+    'scale_buffer':                   ('buffer', 'scale_buffer'),
+}
+
+
+# LoRA module remapping. Each entry maps an adapter prefix (without
+# `.lora_A.weight` / `.lora_B.weight` suffix) to the equivalent ComfyUI module
+# path whose `.weight` should receive the fused delta.
+def _build_lora_map() -> dict:
+    m = {}
+    # Double-stream blocks: ff -> img_mlp, ff_context -> txt_mlp.
+    # The MLP is nn.Sequential[Linear, SiLUActivation, Linear], so the two
+    # Linears are submodules .0 and .2.
+    for i in range(NUM_DOUBLE_BLOCKS):
+        m[f'transformer_blocks.{i}.ff.linear_in']         = f'double_blocks.{i}.img_mlp.0'
+        m[f'transformer_blocks.{i}.ff.linear_out']        = f'double_blocks.{i}.img_mlp.2'
+        m[f'transformer_blocks.{i}.ff_context.linear_in'] = f'double_blocks.{i}.txt_mlp.0'
+        m[f'transformer_blocks.{i}.ff_context.linear_out']= f'double_blocks.{i}.txt_mlp.2'
+
+    # Single-stream blocks: diffusers `attn.to_out` corresponds to ComfyUI's
+    # fused `linear2` (which carries both attention-out and MLP-out, hence
+    # input dim hidden + mlp_hidden = 4096 + 12288 = 16384).
+    for i in range(NUM_SINGLE_BLOCKS):
+        m[f'single_transformer_blocks.{i}.attn.to_out']   = f'single_blocks.{i}.linear2'
+
+    # Combined time/guidance embedder: linear_1 -> in_layer, linear_2 -> out_layer.
+    m['time_guidance_embed.timestep_embedder.linear_1']   = 'time_in.in_layer'
+    m['time_guidance_embed.timestep_embedder.linear_2']   = 'time_in.out_layer'
+
+    return m
+
+
+LORA_MAP = _build_lora_map()
+
+
+@dataclass
+class TranslatedAdapter:
+    # bfl_param_path -> tensor (full-weight overwrite)
+    weight_overrides: dict
+    # bfl_module_path -> (expected_shape, tensor) (module replacement)
+    module_replacements: dict
+    # buffer_name -> tensor (register on transformer)
+    buffers: dict
+    # bfl_module_path -> {'A': tensor, 'B': tensor}  (fuse into module.weight)
+    lora_pairs: dict
+    # any keys we didn't recognize
+    unknown_keys: list
+
+
+def _split_lora_key(adapter_key: str) -> Optional[tuple]:
+    """Return (prefix, 'A' | 'B') or None if the key isn't a LoRA tensor."""
+    if adapter_key.endswith('.lora_A.weight'):
+        return adapter_key[:-len('.lora_A.weight')], 'A'
+    if adapter_key.endswith('.lora_B.weight'):
+        return adapter_key[:-len('.lora_B.weight')], 'B'
+    return None
+
+
+def translate(adapter_state_dict: dict) -> TranslatedAdapter:
+    """Classify every adapter key into an override, buffer, replacement or LoRA pair.
+
+    `adapter_state_dict` is a {str: Tensor-like}. Tensors are not modified here;
+    the loader applies them downstream.
+    """
+    weight_overrides = {}
+    module_replacements = {}
+    buffers = {}
+    lora_pairs: dict = {}
+    unknown_keys = []
+
+    for key, tensor in adapter_state_dict.items():
+        lora = _split_lora_key(key)
+        if lora is not None:
+            prefix, slot = lora
+            bfl_target = LORA_MAP.get(prefix)
+            if bfl_target is None:
+                unknown_keys.append(key)
+                continue
+            lora_pairs.setdefault(bfl_target, {})[slot] = tensor
+            continue
+
+        action = FULL_OVERRIDES.get(key)
+        if action is None:
+            unknown_keys.append(key)
+            continue
+
+        kind = action[0]
+        if kind == 'weight':
+            weight_overrides[action[1]] = tensor
+        elif kind == 'module_replace':
+            module_replacements[action[1]] = (action[2], tensor)
+        elif kind == 'buffer':
+            buffers[action[1]] = tensor
+        else:
+            unknown_keys.append(key)
+
+    return TranslatedAdapter(
+        weight_overrides=weight_overrides,
+        module_replacements=module_replacements,
+        buffers=buffers,
+        lora_pairs=lora_pairs,
+        unknown_keys=unknown_keys,
+    )
+
+
+def expected_adapter_keys() -> set:
+    """The full set of keys we expect to see in a valid AsymFLUX.2-klein-9B adapter.
+
+    Useful for sanity-checking a new release: any key in the adapter not in
+    this set is unknown; any key in this set not in the adapter is missing.
+    """
+    keys = set(FULL_OVERRIDES.keys())
+    for prefix in LORA_MAP:
+        keys.add(f'{prefix}.lora_A.weight')
+        keys.add(f'{prefix}.lora_B.weight')
+    return keys

--- a/comfyui/ComfyUI-AsymFlux2/nodes.py
+++ b/comfyui/ComfyUI-AsymFlux2/nodes.py
@@ -1,0 +1,242 @@
+"""ComfyUI nodes for Lakonik's AsymFLUX.2-klein adapter.
+
+Workflow:
+
+    [UNETLoader (flux2-klein-base-9b)] -> MODEL
+              \\
+               -> [AsymFlux2LoadAdapter (path=...)] -> MODEL  (patched)
+                              |
+    [CLIP encode +/-] -> COND
+    [AsymFlux2EmptyLatent (w,h)] -> LATENT  (3-channel pixel-space noise)
+    [AsymFlux2Sigmas (steps,w,h)] -> SIGMAS
+    [KSamplerSelect (uni_pc)] -> SAMPLER
+              \\
+               -> [SamplerCustom] -> LATENT  (denoised, 3-channel)
+                              |
+                              -> [OklabDecode] -> IMAGE -> [SaveImage]
+
+We deliberately avoid replacing ComfyUI's KSampler -- standard SamplerCustom +
+UniPC works once the sigmas are right and the model accepts (B, 3, H, W) input.
+"""
+
+import os
+import torch
+
+try:
+    from safetensors.torch import load_file as load_safetensors
+except ImportError:
+    load_safetensors = None
+
+import folder_paths  # ComfyUI module; only available when running inside ComfyUI
+
+from .adapter_loader import apply_adapter
+from .scheduler import compute_sigmas
+from .oklab import (
+    encode_image_to_oklab_latent,
+    decode_oklab_latent_to_image,
+)
+from .key_map import (
+    ASYMFLUX_PATCH_SIZE,
+    ASYMFLUX_IN_CHANNELS,
+    ASYMFLUX_OUT_CHANNELS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Adapter loader
+# ---------------------------------------------------------------------------
+
+class AsymFlux2LoadAdapter:
+    """Mutates a stock FLUX.2-klein-9B model into AsymFLUX.2-klein.
+
+    The base MODEL must already be a FLUX.2 klein checkpoint loaded via the
+    standard UNETLoader / CheckpointLoaderSimple. This node performs in-place
+    surgery: replaces img_in / final_layer.linear with new shapes, overwrites
+    final_layer.adaLN_modulation, registers proj_buffer/scale_buffer, and
+    fuses the rank-256 LoRA deltas into 58 weight tensors.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        # The adapter safetensors should sit in models/asymflux2/.
+        return {
+            'required': {
+                'model': ('MODEL',),
+                'adapter_name': (folder_paths.get_filename_list('asymflux2'),),
+            },
+            'optional': {
+                'strict': ('BOOLEAN', {'default': True}),
+            },
+        }
+
+    RETURN_TYPES = ('MODEL',)
+    FUNCTION = 'load'
+    CATEGORY = 'AsymFlux2'
+
+    def load(self, model, adapter_name: str, strict: bool = True):
+        if load_safetensors is None:
+            raise RuntimeError(
+                'safetensors is not installed; run `pip install safetensors` '
+                'inside the ComfyUI environment.')
+        adapter_path = folder_paths.get_full_path('asymflux2', adapter_name)
+        state = load_safetensors(adapter_path)
+
+        # Clone the model patcher so we don't clobber the user's base model.
+        patched = model.clone()
+
+        # ComfyUI loads weights lazily into VRAM; force-load and then unpatch
+        # so we can touch the underlying nn.Module without confusing the
+        # patcher's bookkeeping.
+        try:
+            patched.unpatch_model(device_to=torch.device('cpu'), unpatch_weights=True)
+        except Exception:
+            pass
+
+        flux = patched.model.diffusion_model
+
+        # Pick compute dtype that matches the existing img_in (i.e. the base model).
+        try:
+            compute_dtype = flux.img_in.weight.dtype
+        except AttributeError:
+            compute_dtype = torch.bfloat16
+
+        manifest = apply_adapter(
+            flux, state, compute_dtype=compute_dtype, strict=strict)
+
+        # Re-declare patch grid / channels so Flux.process_img patches correctly.
+        flux.patch_size = ASYMFLUX_PATCH_SIZE
+        flux.in_channels = ASYMFLUX_IN_CHANNELS * ASYMFLUX_PATCH_SIZE ** 2
+        flux.out_channels = ASYMFLUX_OUT_CHANNELS * ASYMFLUX_PATCH_SIZE ** 2
+
+        print(f'[AsymFlux2LoadAdapter] applied adapter `{adapter_name}`:'
+              f' replaced={len(manifest["replaced_modules"])},'
+              f' overwrote={len(manifest["overwrote_weights"])},'
+              f' buffers={len(manifest["registered_buffers"])},'
+              f' fused_loras={len(manifest["fused_loras"])},'
+              f' skipped={len(manifest["skipped"])}')
+
+        return (patched,)
+
+
+# ---------------------------------------------------------------------------
+# Empty pixel-space latent
+# ---------------------------------------------------------------------------
+
+class AsymFlux2EmptyLatent:
+    """3-channel pixel-resolution latent of zeros, ready to be seeded with
+    noise by SamplerCustom."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            'required': {
+                'width':  ('INT', {'default': 1024, 'min': 64, 'max': 4096, 'step': 16}),
+                'height': ('INT', {'default': 1024, 'min': 64, 'max': 4096, 'step': 16}),
+                'batch_size': ('INT', {'default': 1, 'min': 1, 'max': 16}),
+            },
+        }
+
+    RETURN_TYPES = ('LATENT',)
+    FUNCTION = 'build'
+    CATEGORY = 'AsymFlux2'
+
+    def build(self, width: int, height: int, batch_size: int):
+        # Width/height must be multiples of patch_size (16).
+        if width % ASYMFLUX_PATCH_SIZE or height % ASYMFLUX_PATCH_SIZE:
+            raise ValueError(
+                f'width and height must be multiples of {ASYMFLUX_PATCH_SIZE}; '
+                f'got {width}x{height}')
+        samples = torch.zeros(
+            (batch_size, ASYMFLUX_IN_CHANNELS, height, width), dtype=torch.float32)
+        return ({'samples': samples},)
+
+
+# ---------------------------------------------------------------------------
+# Sigma schedule
+# ---------------------------------------------------------------------------
+
+class AsymFlux2Sigmas:
+    """Produces the sqrt-shift sigmas LakonLab's FlowAdapterScheduler would
+    have produced for the given image size and step count."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            'required': {
+                'steps':  ('INT', {'default': 38, 'min': 1, 'max': 500}),
+                'width':  ('INT', {'default': 1024, 'min': 64, 'max': 4096}),
+                'height': ('INT', {'default': 1024, 'min': 64, 'max': 4096}),
+            },
+            'optional': {
+                'base_shift': ('FLOAT', {'default': 17.0, 'min': 0.1, 'max': 100.0}),
+                'max_shift':  ('FLOAT', {'default': 34.0, 'min': 0.1, 'max': 100.0}),
+            },
+        }
+
+    RETURN_TYPES = ('SIGMAS',)
+    FUNCTION = 'build'
+    CATEGORY = 'AsymFlux2'
+
+    def build(self, steps: int, width: int, height: int,
+              base_shift: float = 17.0, max_shift: float = 34.0):
+        sigmas = compute_sigmas(
+            num_inference_steps=steps,
+            image_pixel_count=width * height,
+            base_shift=base_shift,
+            max_shift=max_shift,
+        )
+        return (sigmas,)
+
+
+# ---------------------------------------------------------------------------
+# Oklab encode / decode (replaces VAE)
+# ---------------------------------------------------------------------------
+
+class OklabEncode:
+    """ComfyUI IMAGE -> 3-channel Oklab latent (after the affine norm)."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {'required': {'image': ('IMAGE',)}}
+
+    RETURN_TYPES = ('LATENT',)
+    FUNCTION = 'encode'
+    CATEGORY = 'AsymFlux2'
+
+    def encode(self, image: torch.Tensor):
+        latent = encode_image_to_oklab_latent(image)
+        return ({'samples': latent},)
+
+
+class OklabDecode:
+    """3-channel Oklab latent -> ComfyUI IMAGE."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {'required': {'samples': ('LATENT',)}}
+
+    RETURN_TYPES = ('IMAGE',)
+    FUNCTION = 'decode'
+    CATEGORY = 'AsymFlux2'
+
+    def decode(self, samples: dict):
+        latent = samples['samples']
+        img = decode_oklab_latent_to_image(latent)
+        return (img,)
+
+
+NODE_CLASS_MAPPINGS = {
+    'AsymFlux2LoadAdapter': AsymFlux2LoadAdapter,
+    'AsymFlux2EmptyLatent': AsymFlux2EmptyLatent,
+    'AsymFlux2Sigmas':      AsymFlux2Sigmas,
+    'OklabEncode':          OklabEncode,
+    'OklabDecode':          OklabDecode,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    'AsymFlux2LoadAdapter': 'AsymFLUX.2 Load Adapter',
+    'AsymFlux2EmptyLatent': 'AsymFLUX.2 Empty Latent (pixel)',
+    'AsymFlux2Sigmas':      'AsymFLUX.2 Sigmas (sqrt-shift)',
+    'OklabEncode':          'Oklab Encode (image -> latent)',
+    'OklabDecode':          'Oklab Decode (latent -> image)',
+}

--- a/comfyui/ComfyUI-AsymFlux2/oklab.py
+++ b/comfyui/ComfyUI-AsymFlux2/oklab.py
@@ -1,0 +1,91 @@
+"""Oklab colorspace transform, faithful port of LakonLab's `OklabColorEncoder`
+with the affine-normalization parameters used by AsymFLUX.2 klein:
+
+    mean = (0.56, 0.0, 0.01),  std = 0.16
+
+ComfyUI tensor conventions:
+    IMAGE  -> (B, H, W, 3) in sRGB [0, 1]
+    LATENT -> (B, C, H, W) in floats, no fixed range
+
+AsymFLUX expects 3-channel pixel-space "latents" in Oklab after the affine
+normalization. There is no learned decoder; encode/decode are deterministic.
+"""
+
+import torch
+
+try:
+    from .key_map import OKLAB_AFFINE_MEAN, OKLAB_AFFINE_STD
+except ImportError:
+    from key_map import OKLAB_AFFINE_MEAN, OKLAB_AFFINE_STD
+
+
+# Standard Oklab matrices (Bjorn Ottosson). All in float32 for accuracy.
+_LRGB_TO_LMS = torch.tensor([
+    [0.4122214708, 0.5363325363, 0.0514459929],
+    [0.2119034982, 0.6806995451, 0.1073969566],
+    [0.0883024619, 0.2817188376, 0.6299787005],
+], dtype=torch.float32)
+
+_LMS_TO_OKLAB = torch.tensor([
+    [0.2104542553,  0.7936177850, -0.0040720468],
+    [1.9779984951, -2.4285922050,  0.4505937099],
+    [0.0259040371,  0.7827717662, -0.8086757660],
+], dtype=torch.float32)
+
+
+def _matmul_chw(M: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    """Apply 3x3 matrix M to a (B, 3, H, W) tensor along the channel dim."""
+    # einsum keeps device/dtype of x; cast M to match for speed but keep f32 for fidelity.
+    return torch.einsum('ij,bj...->bi...', M.to(x.device, x.dtype), x)
+
+
+def srgb_to_lrgb(srgb: torch.Tensor) -> torch.Tensor:
+    a = 0.055
+    return torch.where(srgb <= 0.04045, srgb / 12.92, ((srgb + a) / (1 + a)) ** 2.4)
+
+
+def lrgb_to_srgb(lrgb: torch.Tensor) -> torch.Tensor:
+    lrgb = lrgb.clamp(min=0)
+    a = 0.055
+    return torch.where(lrgb <= 0.0031308, lrgb * 12.92, (1 + a) * (lrgb ** (1 / 2.4)) - a)
+
+
+def lrgb_to_oklab(lrgb: torch.Tensor) -> torch.Tensor:
+    lms = _matmul_chw(_LRGB_TO_LMS, lrgb).clamp(min=0)
+    return _matmul_chw(_LMS_TO_OKLAB, lms.pow(1 / 3))
+
+
+def oklab_to_lrgb(oklab: torch.Tensor) -> torch.Tensor:
+    oklab_to_lms = torch.linalg.inv(_LMS_TO_OKLAB).to(oklab.device, oklab.dtype)
+    lms_to_lrgb = torch.linalg.inv(_LRGB_TO_LMS).to(oklab.device, oklab.dtype)
+    lms = torch.einsum('ij,bj...->bi...', oklab_to_lms, oklab).pow(3)
+    return torch.einsum('ij,bj...->bi...', lms_to_lrgb, lms).clamp(0, 1)
+
+
+def _affine_vec(device, dtype) -> tuple:
+    mean = torch.tensor(OKLAB_AFFINE_MEAN, device=device, dtype=dtype).view(1, 3, 1, 1)
+    std = torch.tensor([OKLAB_AFFINE_STD] * 3, device=device, dtype=dtype).view(1, 3, 1, 1)
+    return mean, std
+
+
+def encode_image_to_oklab_latent(image_bhwc_srgb: torch.Tensor) -> torch.Tensor:
+    """ComfyUI IMAGE (B, H, W, 3) sRGB [0,1] -> Oklab "latent" (B, 3, H, W).
+
+    Uses the same arithmetic as LakonLab's OklabColorEncoder.encode().
+    """
+    # to (B, 3, H, W) f32
+    x = image_bhwc_srgb.permute(0, 3, 1, 2).contiguous().to(torch.float32)
+    lrgb = srgb_to_lrgb(x)
+    oklab = lrgb_to_oklab(lrgb)
+    mean, std = _affine_vec(oklab.device, oklab.dtype)
+    return (oklab - mean) / std
+
+
+def decode_oklab_latent_to_image(oklab_latent_bchw: torch.Tensor) -> torch.Tensor:
+    """Oklab "latent" (B, 3, H, W) -> ComfyUI IMAGE (B, H, W, 3) sRGB [0,1]."""
+    x = oklab_latent_bchw.to(torch.float32)
+    mean, std = _affine_vec(x.device, x.dtype)
+    oklab = x * std + mean
+    lrgb = oklab_to_lrgb(oklab)
+    srgb = lrgb_to_srgb(lrgb)
+    return srgb.permute(0, 2, 3, 1).contiguous().clamp(0, 1)

--- a/comfyui/ComfyUI-AsymFlux2/scheduler.py
+++ b/comfyui/ComfyUI-AsymFlux2/scheduler.py
@@ -1,0 +1,65 @@
+"""Port of LakonLab's `FlowAdapterScheduler` sigma computation for AsymFLUX.2.
+
+We only port the sigma-schedule generation. ComfyUI's UniPC sampler will
+consume the resulting `sigmas` tensor and run the actual denoising loop.
+
+Defaults below come from `demo/example_asymflux2_klein_pipeline.py`:
+
+    shift=17.0, use_dynamic_shifting=True,
+    base_seq_len=1024**2, max_seq_len=2048**2,
+    base_logshift=ln(17.0), max_logshift=ln(34.0),
+    dynamic_shifting_type='sqrt',
+    base_scheduler='UniPCMultistep'
+
+`seq_len` here is the value passed to LakonLab's `set_timesteps`, which the
+pipeline computes as `latents.shape[2:].numel()` -- i.e. pixel count of the
+target image (height * width), not patch count.
+"""
+
+import math
+import numpy as np
+import torch
+
+DEFAULT_SHIFT_BASE = 17.0
+DEFAULT_SHIFT_MAX = 34.0
+DEFAULT_BASE_SEQ_LEN = 1024 ** 2
+DEFAULT_MAX_SEQ_LEN = 2048 ** 2
+DEFAULT_EPS = 1e-6
+
+
+def compute_shift(
+        image_pixel_count: int,
+        base_shift: float = DEFAULT_SHIFT_BASE,
+        max_shift: float = DEFAULT_SHIFT_MAX,
+        base_seq_len: int = DEFAULT_BASE_SEQ_LEN,
+        max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
+) -> float:
+    """Sqrt-interpolated shift between (base_shift, max_shift) over sqrt(seq_len)."""
+    sqrt_base = math.sqrt(base_seq_len)
+    sqrt_max = math.sqrt(max_seq_len)
+    m = (max_shift - base_shift) / (sqrt_max - sqrt_base)
+    return (math.sqrt(image_pixel_count) - sqrt_base) * m + base_shift
+
+
+def compute_sigmas(
+        num_inference_steps: int,
+        image_pixel_count: int,
+        base_shift: float = DEFAULT_SHIFT_BASE,
+        max_shift: float = DEFAULT_SHIFT_MAX,
+        base_seq_len: int = DEFAULT_BASE_SEQ_LEN,
+        max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
+        eps: float = DEFAULT_EPS,
+) -> torch.Tensor:
+    """Returns a `torch.float32` 1-D tensor of length `num_inference_steps + 1`,
+    ending in 0.0, ready to hand to ComfyUI's UniPC sampler.
+    """
+    shift = compute_shift(image_pixel_count, base_shift, max_shift,
+                          base_seq_len, max_seq_len)
+
+    sigmas = np.linspace(1.0, 0.0, num_inference_steps, endpoint=False, dtype=np.float32)
+    sigmas = shift * sigmas / (1.0 + (shift - 1.0) * sigmas)
+
+    # UniPCMultistep path clamps sigmas to <= 1 - eps.
+    sigmas = np.clip(sigmas, a_min=None, a_max=1.0 - eps)
+    sigmas = np.concatenate([sigmas, np.zeros(1, dtype=np.float32)], axis=0)
+    return torch.from_numpy(sigmas)

--- a/comfyui/ComfyUI-AsymFlux2/tests/test_apply_adapter.py
+++ b/comfyui/ComfyUI-AsymFlux2/tests/test_apply_adapter.py
@@ -1,0 +1,253 @@
+"""Unit-tests for the adapter-loader surgery primitives.
+
+We don't build a real-sized FLUX stub here (FLUX.2's ~5 B params don't fit in
+the 15 GB sandbox). Instead we exercise each surgery primitive
+(_fuse_lora_into_weight, module replacement, buffer registration, weight
+overwrite) against a tiny synthetic module that has the same hierarchy as
+a real FLUX block.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+try:
+    import torch
+    import torch.nn as nn
+except ImportError:
+    print('[skip] torch not installed')
+    sys.exit(0)
+
+from adapter_loader import (
+    apply_adapter,
+    _fuse_lora_into_weight,
+    _get_submodule,
+    _set_submodule,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. LoRA fusion math
+# ---------------------------------------------------------------------------
+
+def test_fuse_lora_matches_manual_matmul_in_fp32():
+    """Verify the fusion math directly in fp32 storage so the test isn't gated
+    on bf16's ~0.4% storage precision."""
+    torch.manual_seed(0)
+    linear = nn.Linear(64, 128, bias=False)  # fp32
+    base = linear.weight.detach().clone()
+    A = torch.randn(8, 64)
+    B = torch.randn(128, 8)
+
+    _fuse_lora_into_weight(linear.weight, A, B, scaling=1.0)
+
+    expected = base + (B @ A)
+    got = linear.weight.detach()
+    err = (expected - got).abs().max().item()
+    assert err < 1e-5, f'max error after fuse = {err}'
+
+
+def test_fuse_lora_scaling():
+    torch.manual_seed(1)
+    linear = nn.Linear(32, 64, bias=False).to(torch.bfloat16)
+    base = linear.weight.detach().clone().to(torch.float32)
+    A = torch.randn(4, 32, dtype=torch.float16)
+    B = torch.randn(64, 4, dtype=torch.float16)
+
+    _fuse_lora_into_weight(linear.weight, A, B, scaling=0.5)
+
+    expected = base + 0.5 * (B.to(torch.float32) @ A.to(torch.float32))
+    got = linear.weight.detach().to(torch.float32)
+    assert (expected - got).abs().max().item() < 0.05
+
+
+def test_fuse_lora_shape_validation():
+    linear = nn.Linear(64, 128, bias=False).to(torch.bfloat16)
+    A_wrong = torch.randn(8, 32)  # in_features mismatch
+    B = torch.randn(128, 8)
+    try:
+        _fuse_lora_into_weight(linear.weight, A_wrong, B, scaling=1.0)
+    except AssertionError:
+        return
+    raise AssertionError('expected AssertionError on incompatible lora_A shape')
+
+
+# ---------------------------------------------------------------------------
+# 2. Submodule walk / replacement
+# ---------------------------------------------------------------------------
+
+def test_get_and_set_submodule_nested():
+    class Inner(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(2, 2)
+
+    class Outer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = nn.ModuleList([Inner(), Inner()])
+            self.head = nn.Sequential(nn.SiLU(), nn.Linear(4, 4))
+
+    m = Outer()
+
+    # Get
+    assert _get_submodule(m, 'blocks.1.lin') is m.blocks[1].lin
+    assert _get_submodule(m, 'head.1') is m.head[1]
+
+    # Set
+    new_lin = nn.Linear(8, 8)
+    _set_submodule(m, 'blocks.0.lin', new_lin)
+    assert m.blocks[0].lin is new_lin
+
+
+# ---------------------------------------------------------------------------
+# 3. apply_adapter end-to-end on a *one-block* miniature
+# ---------------------------------------------------------------------------
+
+class _TinyFlux(nn.Module):
+    """One double block, one single block, time_in, img_in, final_layer.
+    All dims scaled down. This stays well under 100 MB."""
+
+    def __init__(self):
+        super().__init__()
+        H = 64
+        MH = 96  # mlp_hidden
+
+        # img_in: starts at "latent-FLUX dims" (32 in) and will be replaced with (768, H).
+        self.img_in = nn.Linear(32, H, bias=False)
+
+        # time_in
+        class TI(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.in_layer = nn.Linear(256, H, bias=False)
+                self.out_layer = nn.Linear(H, H, bias=False)
+        self.time_in = TI()
+
+        # one double block (i=0)
+        class DB(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.img_mlp = nn.Sequential(
+                    nn.Linear(H, MH * 2, bias=False), nn.SiLU(),
+                    nn.Linear(MH, H, bias=False))
+                self.txt_mlp = nn.Sequential(
+                    nn.Linear(H, MH * 2, bias=False), nn.SiLU(),
+                    nn.Linear(MH, H, bias=False))
+        self.double_blocks = nn.ModuleList([DB()])
+
+        # one single block (i=0)
+        class SB(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear2 = nn.Linear(H + MH, H, bias=False)
+        self.single_blocks = nn.ModuleList([SB()])
+
+        # final_layer
+        class FL(nn.Module):
+            def __init__(self):
+                super().__init__()
+                # adaLN_modulation.1 ends at 2*H = 128 (matches FLUX layout)
+                self.adaLN_modulation = nn.Sequential(
+                    nn.SiLU(), nn.Linear(H, 2 * H, bias=False))
+                self.linear = nn.Linear(H, 32, bias=False)
+        self.final_layer = FL()
+
+
+def _mini_adapter_for_one_block():
+    """Build a state_dict targeting just block 0 + time_in + I/O, with sizes
+    matching _TinyFlux. NOTE: x_embedder/proj_out/norm_out/proj_buffer have
+    shapes hardcoded in key_map -- so we MUST honor those exact shapes."""
+    torch.manual_seed(2)
+    H = 64
+    MH = 96
+    R = 4  # lora rank for the test
+
+    sd = {}
+
+    # 5 full-overrides at the canonical AsymFLUX shapes:
+    #   x_embedder: (4096, 768)  -- but our tiny model uses H=64; so the
+    #   replacement target shape needs to match what key_map declares. The
+    #   replaced Linear ends up with weight (768, 4096), not interacting with
+    #   the rest of our tiny block.
+    sd['x_embedder.weight']      = torch.randn(4096, 768, dtype=torch.float16)
+    sd['proj_out.weight']        = torch.randn(768, 4096, dtype=torch.float16)
+    sd['norm_out.linear.weight'] = torch.randn(2 * 4096, 4096, dtype=torch.float16)
+    sd['proj_buffer']            = torch.randn(768, 128, dtype=torch.bfloat16)
+    sd['scale_buffer']           = torch.tensor(0.5, dtype=torch.bfloat16)
+    return sd
+
+
+def test_unknown_key_strict_raises():
+    model = _TinyFlux().to(torch.bfloat16)
+    sd = _mini_adapter_for_one_block()
+    sd['something.bogus.weight'] = torch.zeros(1)
+    try:
+        apply_adapter(model, sd, compute_dtype=torch.bfloat16, strict=True)
+    except KeyError:
+        return
+    raise AssertionError('expected KeyError for bogus key')
+
+
+def test_module_replacement_is_size_768():
+    """The full-override shapes are baked into key_map; verify the replaced
+    submodules end up at the canonical FLUX.2-pixel dims."""
+    # We can't apply the full adapter to _TinyFlux because the
+    # norm_out.linear.weight (8192, 4096) won't match _TinyFlux's
+    # adaLN_modulation[1] of shape (128, 64). So instead build a model whose
+    # adaLN_modulation matches the real shape and skip the block LoRAs.
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.img_in = nn.Linear(32, 4096, bias=False)
+            class FL(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.adaLN_modulation = nn.Sequential(
+                        nn.SiLU(), nn.Linear(4096, 8192, bias=False))
+                    self.linear = nn.Linear(4096, 32, bias=False)
+            self.final_layer = FL()
+    model = M().to(torch.bfloat16)
+
+    sd = {
+        'x_embedder.weight':      torch.randn(4096, 768, dtype=torch.float16),
+        'proj_out.weight':        torch.randn(768, 4096, dtype=torch.float16),
+        'norm_out.linear.weight': torch.randn(8192, 4096, dtype=torch.float16),
+        'proj_buffer':            torch.randn(768, 128, dtype=torch.bfloat16),
+        'scale_buffer':           torch.tensor(0.5, dtype=torch.bfloat16),
+    }
+
+    # Loose strict because we're not providing the 116 LoRA halves.
+    manifest = apply_adapter(model, sd, compute_dtype=torch.bfloat16, strict=False)
+    assert 'img_in' in manifest['replaced_modules']
+    assert 'final_layer.linear' in manifest['replaced_modules']
+    assert model.img_in.in_features == 768
+    assert model.img_in.out_features == 4096
+    assert model.final_layer.linear.in_features == 4096
+    assert model.final_layer.linear.out_features == 768
+    assert 'proj_buffer' in manifest['registered_buffers']
+    assert 'scale_buffer' in manifest['registered_buffers']
+    assert model.proj_buffer.shape == (768, 128)
+    assert model.scale_buffer.shape == ()
+
+
+if __name__ == '__main__':
+    funcs = [v for k, v in globals().items() if k.startswith('test_') and callable(v)]
+    failures = 0
+    for fn in funcs:
+        try:
+            fn()
+            print(f'PASS  {fn.__name__}')
+        except AssertionError as e:
+            failures += 1
+            print(f'FAIL  {fn.__name__}: {e}')
+        except Exception as e:
+            failures += 1
+            import traceback
+            print(f'ERROR {fn.__name__}:')
+            traceback.print_exc()
+    if failures:
+        sys.exit(1)
+    print(f'\nAll {len(funcs)} tests passed.')

--- a/comfyui/ComfyUI-AsymFlux2/tests/test_key_translation.py
+++ b/comfyui/ComfyUI-AsymFlux2/tests/test_key_translation.py
@@ -1,0 +1,97 @@
+"""Validate the key-translation map against the known 121-key adapter dump.
+
+The reference key list below was produced by inspecting the real file
+`Lakonik/AsymFLUX.2-klein-9B/diffusion_pytorch_model.safetensors`.
+
+This test imports only `key_map` (no torch, no diffusers, no ComfyUI) and runs
+in well under a second. If a future adapter release adds or removes keys, this
+will flag it immediately.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import key_map
+
+
+REFERENCE_KEYS = """
+norm_out.linear.weight
+proj_buffer
+proj_out.weight
+scale_buffer
+x_embedder.weight
+time_guidance_embed.timestep_embedder.linear_1.lora_A.weight
+time_guidance_embed.timestep_embedder.linear_1.lora_B.weight
+time_guidance_embed.timestep_embedder.linear_2.lora_A.weight
+time_guidance_embed.timestep_embedder.linear_2.lora_B.weight
+""".strip().splitlines()
+
+# Programmatically add the 116 block-level LoRA keys.
+for i in range(24):
+    REFERENCE_KEYS.append(f'single_transformer_blocks.{i}.attn.to_out.lora_A.weight')
+    REFERENCE_KEYS.append(f'single_transformer_blocks.{i}.attn.to_out.lora_B.weight')
+for i in range(8):
+    for sub in ('ff.linear_in', 'ff.linear_out',
+                'ff_context.linear_in', 'ff_context.linear_out'):
+        REFERENCE_KEYS.append(f'transformer_blocks.{i}.{sub}.lora_A.weight')
+        REFERENCE_KEYS.append(f'transformer_blocks.{i}.{sub}.lora_B.weight')
+
+
+def test_reference_set_is_121_keys():
+    assert len(REFERENCE_KEYS) == 121, f'expected 121, got {len(REFERENCE_KEYS)}'
+    assert len(set(REFERENCE_KEYS)) == 121, 'duplicates in reference set'
+
+
+def test_expected_keys_matches_reference():
+    expected = key_map.expected_adapter_keys()
+    ref = set(REFERENCE_KEYS)
+    missing = ref - expected
+    extra = expected - ref
+    assert not missing, f'translation map is missing real keys: {sorted(missing)}'
+    assert not extra,   f'translation map has phantom keys: {sorted(extra)}'
+
+
+def test_translate_classifies_every_key():
+    # Use placeholder tensor stand-ins (just strings); translate() doesn't touch them.
+    fake_state = {k: f'<tensor:{k}>' for k in REFERENCE_KEYS}
+    out = key_map.translate(fake_state)
+    assert out.unknown_keys == [], f'unknown: {out.unknown_keys}'
+    assert len(out.weight_overrides) == 1, out.weight_overrides
+    assert len(out.module_replacements) == 2, out.module_replacements
+    assert len(out.buffers) == 2, out.buffers
+    assert len(out.lora_pairs) == 58, len(out.lora_pairs)
+    # Every LoRA target must have BOTH A and B halves.
+    for target, halves in out.lora_pairs.items():
+        assert set(halves.keys()) == {'A', 'B'}, (target, halves)
+
+
+def test_lora_targets_are_unique():
+    assert len(set(key_map.LORA_MAP.values())) == len(key_map.LORA_MAP), \
+        'two adapter prefixes map to the same BFL module'
+
+
+def test_module_replacement_shapes():
+    # img_in: hidden x (in_channels * patch^2) = 4096 x 768
+    # final_layer.linear: (out_channels * patch^2) x hidden = 768 x 4096
+    img_in_shape = key_map.FULL_OVERRIDES['x_embedder.weight'][2]
+    fl_shape = key_map.FULL_OVERRIDES['proj_out.weight'][2]
+    assert img_in_shape == (4096, 768), img_in_shape
+    assert fl_shape == (768, 4096), fl_shape
+
+
+if __name__ == '__main__':
+    funcs = [v for k, v in globals().items() if k.startswith('test_') and callable(v)]
+    failures = 0
+    for fn in funcs:
+        try:
+            fn()
+            print(f'PASS  {fn.__name__}')
+        except AssertionError as e:
+            failures += 1
+            print(f'FAIL  {fn.__name__}: {e}')
+    if failures:
+        sys.exit(1)
+    print(f'\nAll {len(funcs)} tests passed.')

--- a/comfyui/ComfyUI-AsymFlux2/tests/test_oklab.py
+++ b/comfyui/ComfyUI-AsymFlux2/tests/test_oklab.py
@@ -1,0 +1,83 @@
+"""Oklab encode/decode sanity tests.
+
+We don't have a reference image to byte-compare against, so we instead check:
+  (a) encode -> decode round-trips back to the original image within sRGB
+      precision (gamma curve introduces ~1/255 noise);
+  (b) encode of grey-ish images puts most energy near affine_mean / std=1;
+  (c) shape contract matches ComfyUI's (B, H, W, 3) image convention.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+try:
+    import torch
+except ImportError:
+    print('[skip] torch not installed')
+    sys.exit(0)
+
+from oklab import (
+    encode_image_to_oklab_latent,
+    decode_oklab_latent_to_image,
+    srgb_to_lrgb, lrgb_to_srgb,
+    lrgb_to_oklab, oklab_to_lrgb,
+)
+
+
+def test_srgb_lrgb_roundtrip():
+    x = torch.linspace(0, 1, 256)
+    back = lrgb_to_srgb(srgb_to_lrgb(x))
+    assert (back - x).abs().max() < 1e-5
+
+
+def test_lrgb_oklab_roundtrip():
+    x = torch.rand(1, 3, 8, 8)
+    back = oklab_to_lrgb(lrgb_to_oklab(x))
+    assert (back - x).abs().max() < 1e-3, (back - x).abs().max().item()
+
+
+def test_image_latent_image_roundtrip():
+    # Simulate a ComfyUI IMAGE tensor.
+    torch.manual_seed(0)
+    img = torch.rand(2, 16, 16, 3)
+    latent = encode_image_to_oklab_latent(img)
+    assert latent.shape == (2, 3, 16, 16), latent.shape
+    out = decode_oklab_latent_to_image(latent)
+    assert out.shape == (2, 16, 16, 3), out.shape
+    err = (out - img).abs().max().item()
+    # Some precision loss from gamma + matrix inversion, but should be < 1/255.
+    assert err < 0.01, f'max round-trip error = {err}'
+
+
+def test_mid_grey_normalizes_near_zero_a_b():
+    # A mid-grey image should have oklab a, b near 0 (chromatic axes).
+    img = torch.full((1, 4, 4, 3), 0.5)
+    latent = encode_image_to_oklab_latent(img)
+    a, b = latent[0, 1], latent[0, 2]
+    # After (oklab - mean(0.56,0,0.01)) / std(0.16), a-channel should be near 0,
+    # b-channel near -0.01/0.16 ≈ -0.0625.
+    assert a.abs().max() < 0.05, a.abs().max().item()
+    assert (b + 0.0625).abs().max() < 0.05, b.abs().max().item()
+
+
+if __name__ == '__main__':
+    funcs = [v for k, v in globals().items() if k.startswith('test_') and callable(v)]
+    failures = 0
+    for fn in funcs:
+        try:
+            fn()
+            print(f'PASS  {fn.__name__}')
+        except AssertionError as e:
+            failures += 1
+            print(f'FAIL  {fn.__name__}: {e}')
+        except Exception as e:
+            failures += 1
+            import traceback
+            print(f'ERROR {fn.__name__}:')
+            traceback.print_exc()
+    if failures:
+        sys.exit(1)
+    print(f'\nAll {len(funcs)} tests passed.')

--- a/comfyui/ComfyUI-AsymFlux2/tests/test_scheduler.py
+++ b/comfyui/ComfyUI-AsymFlux2/tests/test_scheduler.py
@@ -1,0 +1,112 @@
+"""Verify the sqrt-shift sigma schedule matches LakonLab's FlowAdapterScheduler
+math exactly.
+
+We replicate the reference math from
+`lakonlab/models/diffusions/schedulers/flow_adapter.py` and compare to our
+port. No torch needed for the reference; we just check our function's
+torch-Tensor output against the numpy reference.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import numpy as np
+
+# Avoid importing scheduler at module level so we can skip if torch is missing.
+try:
+    import torch  # noqa: F401
+    HAVE_TORCH = True
+except ImportError:
+    HAVE_TORCH = False
+
+
+def _reference_sigmas(num_steps, image_pixel_count,
+                      base_shift=17.0, max_shift=34.0,
+                      base_seq_len=1024 ** 2, max_seq_len=2048 ** 2,
+                      eps=1e-6):
+    """LakonLab's exact arithmetic, copied from flow_adapter.py."""
+    sqrt_base = np.sqrt(base_seq_len)
+    sqrt_max = np.sqrt(max_seq_len)
+    m = (max_shift - base_shift) / (sqrt_max - sqrt_base)
+    shift = (np.sqrt(image_pixel_count) - sqrt_base) * m + base_shift
+
+    sigmas = np.linspace(1.0, 0.0, num_steps, endpoint=False, dtype=np.float32)
+    sigmas = shift * sigmas / (1.0 + (shift - 1.0) * sigmas)
+    sigmas = np.clip(sigmas, a_min=None, a_max=1.0 - eps)
+    sigmas = np.concatenate([sigmas, np.zeros(1, dtype=np.float32)], axis=0)
+    return sigmas
+
+
+def test_shift_at_base_returns_base():
+    # If image_pixel_count == base_seq_len, shift should equal base_shift exactly.
+    if not HAVE_TORCH:
+        return
+    from scheduler import compute_shift
+    s = compute_shift(image_pixel_count=1024 ** 2)
+    assert abs(s - 17.0) < 1e-9, s
+
+
+def test_shift_at_max_returns_max():
+    if not HAVE_TORCH:
+        return
+    from scheduler import compute_shift
+    s = compute_shift(image_pixel_count=2048 ** 2)
+    assert abs(s - 34.0) < 1e-9, s
+
+
+def test_sigmas_match_reference():
+    if not HAVE_TORCH:
+        print('[skip] torch not available')
+        return
+    from scheduler import compute_sigmas
+    for steps, pixels in [(38, 960 * 1280), (28, 1024 * 1024), (50, 2048 * 2048)]:
+        ours = compute_sigmas(steps, pixels).cpu().numpy()
+        ref = _reference_sigmas(steps, pixels)
+        assert ours.shape == ref.shape, (ours.shape, ref.shape)
+        assert np.allclose(ours, ref, atol=1e-6, rtol=1e-6), \
+            f'max diff = {np.abs(ours - ref).max()} for steps={steps}, pixels={pixels}'
+
+
+def test_sigmas_are_monotone_decreasing():
+    if not HAVE_TORCH:
+        return
+    from scheduler import compute_sigmas
+    s = compute_sigmas(38, 960 * 1280).cpu().numpy()
+    diffs = np.diff(s)
+    assert (diffs <= 0).all(), f'non-monotone at indices {np.where(diffs > 0)[0]}'
+    assert s[0] < 1.0, s[0]      # clamped below 1
+    assert s[-1] == 0.0, s[-1]
+
+
+def test_default_38_step_schedule_matches_demo_example():
+    # Pure-python reproduction of what the README demo runs.
+    if not HAVE_TORCH:
+        return
+    from scheduler import compute_sigmas
+    sigmas = compute_sigmas(38, 960 * 1280)
+    assert sigmas.shape[0] == 39, sigmas.shape  # 38 steps + final 0
+    # First sigma is shifted but clamped to <=1-1e-6 (compared in float32).
+    expected_clamp = float(np.float32(1.0 - 1e-6))
+    assert abs(sigmas[0].item() - expected_clamp) < 1e-9, sigmas[0].item()
+
+
+if __name__ == '__main__':
+    funcs = [v for k, v in globals().items() if k.startswith('test_') and callable(v)]
+    failures = 0
+    for fn in funcs:
+        try:
+            fn()
+            print(f'PASS  {fn.__name__}')
+        except AssertionError as e:
+            failures += 1
+            print(f'FAIL  {fn.__name__}: {e}')
+        except Exception as e:
+            failures += 1
+            print(f'ERROR {fn.__name__}: {type(e).__name__}: {e}')
+    if failures:
+        sys.exit(1)
+    print(f'\nAll {len(funcs)} tests passed.')


### PR DESCRIPTION
Initial ComfyUI integration for Lakonik AsymFLUX.2-klein-9B. The adapter is a hybrid of 5 full-weight overrides (shape-changing module replacements + new buffers + overwritten weights) plus 116 rank-256 LoRA tensors fused into 58 modules, derived from inspecting the real 121-key safetensors export.

Package contents:
- key_map: diffusers <-> BFL translation table covering all 121 keys
- adapter_loader: module-replacement / buffer registration / LoRA fusion
- oklab: faithful port of LakonLab's OklabColorEncoder (encode + decode)
- scheduler: sqrt-shift sigma schedule matching FlowAdapterScheduler
- nodes: 5 ComfyUI nodes (loader, empty latent, sigmas, oklab encode/decode)
- 20 tests covering key translation, scheduler math vs reference, surgery primitives, and Oklab round-trips; all run without ComfyUI or the 9B base